### PR TITLE
Add "private_only" as configurable template value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ stikked_site_name: "{{ inventory_hostname }} Pastebin Service"
 stikked_theme: centos
 stikked_cron_key: ThisIsAVeryLongKeyThatShouldBeRandomSoChangeIT
 stikked_api_key: ThatOneTooShouldBeRandomizedAtYourVariablesLevel
+stikked_private_only: 'true'
 stikked_enable_captcha: 'false'
 stikked_disable_shorturl: 'true'
 stikked_disable_keep_forever: 'true'

--- a/templates/stikked.php.j2
+++ b/templates/stikked.php.j2
@@ -223,7 +223,7 @@ $config['soft_api'] = false;
  * disallow_search_engines: displays a robots.txt that forbids indexing
  *
 **/
-$config['private_only'] = false;
+$config['private_only'] = {{ stikked_private_only }};
 $config['enable_captcha'] = {{ stikked_enable_captcha }};
 $config['recaptcha_publickey'] = '';
 $config['recaptcha_privatekey'] = '';


### PR DESCRIPTION
Enable "private_only" setting to be set via in the stikked.php.j2 template and default the value to "true" in main.xml.  This prevents display of recent / trending links in the web app and prevents successful execution of the API callouts for all iterative functions (recent/trending/random).