### PR TITLE
Remove unnecessary rewrite rules

### DIFF
--- a/templates/ssl-stikked-vhost.conf.j2
+++ b/templates/ssl-stikked-vhost.conf.j2
@@ -14,8 +14,6 @@
 </Location>
 
 RewriteEngine on
-RewriteRule "^/lists" / 
-RewriteRule "^/trends" / 
 
 
   <Directory "{{ stikked_httpd_dir }}">


### PR DESCRIPTION
The rewrite rules are no longer necessary as the app restricts display and functionality of the iterative links and API calls.